### PR TITLE
Configuration to allow or skip redundant pin writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,21 @@
 
 An improved fork of the [sn74hc595 component](https://esphome.io/components/sn74hc595.html) for ESPHome.
 
-Changes from the base component:
+### Changes from the base component:
 
-* You must add the external component as shown in [the example](#example)
 * `sn74hc595` becomes `sn74hc595i` in your configuration file
 * Pins with `inverted: true` will have the correct state on reset. In short `restore_mode` plays nice with `inverted`.  This avoids relays pulsing on boot-up and reset.
+* Adds `save_writes` to avoid toggling the pin when not necessary, useful when using the 74hc595 on slow interfaces like i2c gpio extenders.
 
-# Example
+## How to use
+
+* Add the external component as shown in [the example](#example)
+
+### Example
 
 ```
 external_components:
-  - source: github://gdgib/esphome_sn74hc595@v0.0.2
+  - source: github://haext/esphome_sn74hc595
 
 sn74hc595i:
   - id: 'sn74hc595_hub'
@@ -23,6 +27,7 @@ sn74hc595i:
 switch:
   - platform: gpio
     name: "SN74HC595 Pin #0"
+    save_writes: true
     pin:
       sn74hc595: sn74hc595_hub
       number: 0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An improved fork of the [sn74hc595 component](https://esphome.io/components/sn74
 
 * `sn74hc595` becomes `sn74hc595i` in your configuration file
 * Pins with `inverted: true` will have the correct state on reset. In short `restore_mode` plays nice with `inverted`.  This avoids relays pulsing on boot-up and reset.
-* Adds `save_writes` to avoid toggling the pin when not necessary, useful when using the 74hc595 on slow interfaces like i2c gpio extenders.
+* It avoids toggling the data pin when not necessary, useful when using the 74hc595 on slow interfaces like i2c gpio extenders; added `force_all_writes` to disable the feature
 
 ## How to use
 
@@ -27,7 +27,7 @@ sn74hc595i:
 switch:
   - platform: gpio
     name: "SN74HC595 Pin #0"
-    save_writes: true
+    force_all_writes: false #default
     pin:
       sn74hc595: sn74hc595_hub
       number: 0

--- a/components/sn74hc595i/__init__.py
+++ b/components/sn74hc595i/__init__.py
@@ -33,7 +33,7 @@ CONF_SN74HC595I = "sn74hc595i"
 CONF_LATCH_PIN = "latch_pin"
 CONF_OE_PIN = "oe_pin"
 CONF_SR_COUNT = "sr_count"
-CONF_SAVE_WRITES = "save_writes"
+CONF_ALL_WRITES = "force_all_writes"
 
 CONFIG_SCHEMA = cv.Any(
     cv.Schema(
@@ -44,7 +44,7 @@ CONFIG_SCHEMA = cv.Any(
             cv.Required(CONF_LATCH_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_OE_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_SR_COUNT, default=1): cv.int_range(min=1, max=256),
-            cv.Optional(CONF_SAVE_WRITES, default=False): cv.boolean,
+            cv.Optional(CONF_ALL_WRITES, default=False): cv.boolean,
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.Schema(
@@ -79,8 +79,8 @@ async def to_code(config):
     else:
         raise EsphomeError("Not supported")
 
-    if config.get(CONF_SAVE_WRITES, False):
-        cg.add_define("SAVE_WRITES")
+    if config.get(CONF_ALL_WRITES, False):
+        cg.add_define("ALL_WRITES")
     latch_pin = await cg.gpio_pin_expression(config[CONF_LATCH_PIN])
     cg.add(var.set_latch_pin(latch_pin))
     if CONF_OE_PIN in config:

--- a/components/sn74hc595i/__init__.py
+++ b/components/sn74hc595i/__init__.py
@@ -33,6 +33,7 @@ CONF_SN74HC595I = "sn74hc595i"
 CONF_LATCH_PIN = "latch_pin"
 CONF_OE_PIN = "oe_pin"
 CONF_SR_COUNT = "sr_count"
+CONF_SAVE_WRITES = "save_writes"
 
 CONFIG_SCHEMA = cv.Any(
     cv.Schema(
@@ -43,6 +44,7 @@ CONFIG_SCHEMA = cv.Any(
             cv.Required(CONF_LATCH_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_OE_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_SR_COUNT, default=1): cv.int_range(min=1, max=256),
+            cv.Optional(CONF_SAVE_WRITES, default=False): cv.boolean,
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.Schema(
@@ -77,6 +79,8 @@ async def to_code(config):
     else:
         raise EsphomeError("Not supported")
 
+    if config.get(CONF_SAVE_WRITES, False):
+        cg.add_define("SAVE_WRITES")
     latch_pin = await cg.gpio_pin_expression(config[CONF_LATCH_PIN])
     cg.add(var.set_latch_pin(latch_pin))
     if CONF_OE_PIN in config:

--- a/components/sn74hc595i/sn74hc595i.cpp
+++ b/components/sn74hc595i/sn74hc595i.cpp
@@ -70,14 +70,16 @@ void SN74HC595IComponent::set_inverted_(uint16_t pin, bool inverted) {
 void SN74HC595IGPIOComponent::write_gpio() {
   auto value = this->value_bytes_.rbegin();
   auto inverted = this->inverted_bytes_.rbegin();
-  #ifdef SAVE_WRITES
+  #ifndef ALL_WRITES
   bool prev_to_write;
   #endif
   while (value != this->value_bytes_.rend() && inverted != this->inverted_bytes_.rend()) {
     for (int8_t i = 7; i >= 0; i--) {
       bool value_bit = (*value >> i) & 1;
       bool value_inverted = (*inverted >> i) & 1;
-      #ifdef SAVE_WRITES
+      #ifdef ALL_WRITES
+        this->data_pin_->digital_write(value_bit != value_inverted);
+      #else
         bool to_write = value_bit != value_inverted;
         if (i < 7) {
           if (prev_to_write != to_write){
@@ -88,8 +90,6 @@ void SN74HC595IGPIOComponent::write_gpio() {
           this->data_pin_->digital_write(to_write);
           prev_to_write = to_write;
         }
-      #else
-      this->data_pin_->digital_write(value_bit != value_inverted);
       #endif
       this->clock_pin_->digital_write(true);
       this->clock_pin_->digital_write(false);
@@ -130,10 +130,6 @@ float SN74HC595IComponent::get_setup_priority() const { return setup_priority::I
 
 void SN74HC595IGPIOPin::digital_write(bool value) { this->parent_->digital_write_(this->pin_, value); }
 void SN74HC595IGPIOPin::set_inverted(bool inverted) { this->parent_->set_inverted_(this->pin_, inverted); }
-#ifdef SAVE_WRITES
-std::string SN74HC595IGPIOPin::dump_summary() const { return str_snprintf("%u via SN74HC595I save_writes", 30, pin_); }
-#else
 std::string SN74HC595IGPIOPin::dump_summary() const { return str_snprintf("%u via SN74HC595I", 18, pin_); }
-#endif
 }  // namespace sn74hc595i
 }  // namespace esphome


### PR DESCRIPTION
I implemented an optimization for the specific case of multiple 74hc595 on a slow gpio interface. In my use case I use 2 - 74hc595 on a i2c extender: when starting up with restore_mode it takes 5 seconds to restore all the gpios if they are not in the default state. With this optimization it takes 3. 

This pull request introduces a new feature, `save_writes`, to the `sn74hc595i` ESPHome component, which helps reduce unnecessary pin toggling. The documentation has been updated to explain this feature.

I'm aware that using a byte of memory to remember the state in a use case so specific is a waste: so I implemented it using flags avoiding the waste when not necessary.

